### PR TITLE
Alternative method to get popular times. Fix bugs in get_circle_centers. Cleanup. Tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 # Populartimes
-The goal of this repository is to provide an option to use Google Maps popular times data, until it is available via Google's API.
+The goal of this script is to provide an option to use Google Maps popular times data, until it is available via Google's API.
 
 ## How to get started
-+ Get a Google Maps API key https://developers.google.com/places/web-service/?hl=de (for more than 1000 reqests/sec add payment information)
-+ Install the wheel via: pip3 install populartimes-2.0-py3.whl
-+ *import populartimes* and run with *populartimes.get(...)*
++ Get a Google Maps API key https://developers.google.com/places/web-service/ (for more than 1000 reqests/sec add payment information).
++ Install the wheel via: `pip3 install populartimes-2.0-py3.whl` or `python setup.py install`
++ `import populartimes` and run with `populartimes.get(...)`
 
-
-## Calling populartimes.get(...)
-+ **populartimes.get**(api_key, types, bound_lower, bound_upper, n_threads (opt), radius (opt), all_places (opt))
+## Calling populartimes.get
++ `populartimes.get(api_key, types, bound_lower, bound_upper, n_threads=20, radius=180, all_places=False):`
     + **api_key** str; api key from google places web service; e.g. "your-api-key"
     + **types** [str]; placetypes; see https://developers.google.com/places/supported_types; e.g. ["bar"]
     + **bound_lower** (float, float); lat/lng of southwest point; e.g. (48.132986, 11.566126)
@@ -17,13 +16,16 @@ The goal of this repository is to provide an option to use Google Maps popular t
     + **radius (opt)** int; meters; from 1-180 for radar search; e.g. 180
     + **all_places (opt)** bool; include/exclude places without populartimes
 
-+ example call:
-    + populartimes.get("your-api-key", ["bar"], (48.132986, 11.566126), (48.142199, 11.580047))
++ example call
+    
+	`populartimes.get("your-api-key", ["bar"], (48.132986, 11.566126), (48.142199, 11.580047))`
+
+See also the examples in `tests/test.py`.
 
 ## Response
-+ The data is represented as a list with json responses according to the example below
-+ The populartimes data for each day is an array of length 24, with populartimes data starting from hour 0 to 23
-+ Example for a place.json
++ The data is represented as a list with json responses according to the example below.
++ The populartimes data for each day is an array of length 24, with populartimes data starting from hour 0 to 23.
++ Example output:
 ```json
 {
   "id": "ChIJ6cI52_EBCUER56PDz9hLEx0",

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,5 @@
+# TODO
+
+- Improve handling of threading.
+- Display progress.
+- Command line utility

--- a/populartimes/__init__.py
+++ b/populartimes/__init__.py
@@ -4,9 +4,7 @@
 from .crawler import run
 
 """
-
 ENTRY POINT
-
 """
 
 
@@ -29,14 +27,8 @@ def get(api_key, types, bound_lower, bound_upper, n_threads=20, radius=180, all_
         "n_threads": n_threads,
         "all_places": all_places,
         "bounds": {
-            "lower": {
-                "lat": bound_lower[0],
-                "lng": bound_lower[1]
-            },
-            "upper": {
-                "lat": bound_upper[0],
-                "lng": bound_upper[1]
-            }
+            "lower": bound_lower,
+            "upper": bound_upper
         }
     }
 

--- a/populartimes/populartimes.py
+++ b/populartimes/populartimes.py
@@ -1,0 +1,133 @@
+import requests
+import logging
+from fake_useragent import UserAgent
+import json
+import calendar
+import re
+from datetime import datetime
+from dateutil.relativedelta import relativedelta, weekdays
+
+
+def get_populartimes(search_term, place_id, explicitDatetimes=False):
+    if place_id is not None:
+        return PopularTimesMaps(explicitDatetimes).get(place_id)
+    return PopularTimesSearch(explicitDatetimes).get(search_term)
+
+
+class PopularTimes(object):
+    def __init__(self, explicitDatetimes=False):
+        self.explicitDatetimes = explicitDatetimes
+
+    def get(self):
+        return
+
+    def _processPopularity(self, popularity):
+        if popularity is None:
+            return None
+        if self.explicitDatetimes:
+            out = {}
+            for i, p in enumerate(popularity):
+                time = datetime.now() + relativedelta(weekday=weekdays[i - 1](-1))  # datetime: mo<->0, google: mo<->1
+                for h in p[1]:
+                    time = time.replace(hour=h[0], minute=0, second=0, microsecond=0)
+                    out[time] = h[1]
+            return out
+        else:
+            # {"name" : "monday", "data": [...]} for each weekday as list
+            days_json = [[0 for _ in range(24)] for _ in range(7)]
+            for day in popularity:
+                day_no, pop_times = day[:2]
+                if pop_times is not None:
+                    for el in pop_times:
+                        hour, pop = el[:2]
+                        days_json[day_no - 1][hour] = pop
+                        # day wrap
+                        if hour == 23:
+                            day_no = day_no % 7 + 1
+            return [{
+                "name": list(calendar.day_name)[d],
+                "data": days_json[d]} for d in range(7)]
+
+
+# First method: via Google search, parsing JSON
+class PopularTimesSearch(PopularTimes):
+    def __init__(self, *args):
+        super().__init__(*args)
+
+    def get(self, search_term, language="en"):
+        """
+        sends request to google/search and parses json response to get data
+        :param place_identifier: string with place name and address
+        :return: tuple with popular times, rating and number of ratings/comments
+        """
+        params_url = {
+            "tbm": "map",
+            "hl": language,
+            "tch": 1,
+            "q": search_term
+        }
+        data = requests.get("https://www.google.com/search", params=params_url, headers={"User-Agent": UserAgent().random}).text
+
+        # find json EOF
+        jend = data.rfind("}")
+        if jend >= 0:
+            data = data[:jend + 1]
+
+        jdata = json.loads(data)["d"]
+        jdata = json.loads(jdata[4:])
+
+        popularity, rating, rating_n = None, None, None
+        try:
+            # get info from result array, has to be adapted if backend api changes
+            info = jdata[0][1][0][14]
+
+            rating = info[4][7]
+            rating_n = info[4][8]
+            popularity = self._processPopularity(info[84][0])
+
+        # ignore, there is either no info available or no popular times
+        # TypeError: rating/rating_n/populartimes in None
+        # IndexError: info is not available
+        except (TypeError, IndexError) as e:
+            pass
+
+        return popularity, rating, rating_n
+
+
+# Second method: via Google maps
+class PopularTimesMaps(PopularTimes):
+    def __init__(self, *args):
+        super().__init__(*args)
+
+    def get(self, place_id, dryscrape=False):
+        url = "https://www.google.com/maps/place/?q=place_id:{}&force=tt".format(place_id)
+        reg = r"\[" + r"(?:\[\d+,\[" + r"(?:\[\d+,\d+,(?:.*?)\]\\n,*)+" + r"\]\\n,\d+\]\\n,*)+\]\\n"
+        if not dryscrape:
+            t = requests.get(url, headers={'User-Agent': UserAgent().random, 'Cache-Control': 'no-cache'}).text
+        else:
+            import dryscrape
+            logging.info("Using dryscrape")
+            dryscrape.start_xvfb()
+            s = dryscrape.Session()
+            s.set_attribute("auto_load_images", False)
+            s.visit(url)
+            s.at_css(".section-popular-times", timeout=30)
+            t = s.body()
+        # Popularity
+        pop = re.findall(reg, t)[0]
+        pop = pop.replace("\\n", "")
+        pop = pop.replace(r'\"', '"')
+        pop = json.loads(pop)
+        popularity = self._processPopularity(pop)
+
+        # Current popularity
+        # popularity[datetime.now()] = int(re.findall(r"\dp(?:.*?)\[{},(\d+)\]\\n]\\n,".format(datetime.now().hour), t)[0])
+
+        # Reviews
+        reviews = re.findall("((?:\d|,)+)\s*reviews", t)[0]
+        reviews = reviews.replace(",", "")
+        reviews = int(reviews)
+        # Rating
+        rating = float(re.findall("((?:\d|\.)+),{}".format(reviews), t)[0])
+
+        return popularity, rating, reviews

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+dryscrape==1.0
+fake_useragent==0.1.5
+geopy==1.11.0
+requests==2.11.1
+setuptools==36.5.0

--- a/setup.py
+++ b/setup.py
@@ -40,12 +40,10 @@ setup(
     # simple. Or you can use find_packages().
     packages=find_packages(exclude=['content', 'test']),
 
-    # List run-time dependencies here.  These will be installed by pip when
-    # your project is installed. For an analysis of "install_requires" vs pip's
-    # requirements files see:
-    # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'requests'
+        'requests',
+        'geopy',
+        'fake_useragent'
     ],
 
     # TODO

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,14 +1,27 @@
+import unittest
 import populartimes
+from populartimes.populartimes import get_populartimes
 from pprint import pprint
 import logging
 
 logging.getLogger().setLevel(logging.INFO)
 
-key = "" # Add your API key
+key = ""  # Add your API key
+
+
+class BasicTests(unittest.TestCase):
+    def test_populartimes_search(self):
+        # Google search
+        pprint(get_populartimes("Hirschau Gyßlingstraße 15, 80805 München, Germany", None))
+
+    def test_populartimes_maps(self):
+        # Google Maps, with detailed datetimes
+        pprint(get_populartimes(None, "ChIJw-H-HGHfnUcR9FPDibLs4oU", True))
+        pprint(get_populartimes(None, "ChIJEZt-OnnfnUcRXm13XMQbdvU", True))
+
+    def test_full(self):
+        pprint(populartimes.get(key, ["bar"], (48.142199, 11.566126), (48.132986, 11.580047), radius=5000, n_threads=1))
+
 
 if __name__ == "__main__":
-    pprint(populartimes.get(key, ["bar"], (48.142199, 11.566126), (48.132986, 11.580047), radius=5000, n_threads=1))
-    # Popular times
-    from populartimes.populartimes import get_populartimes
-    pprint(get_populartimes("Hirschau Gyßlingstraße 15, 80805 München, Germany", None)) # Google search
-    pprint(get_populartimes(None, "ChIJw-H-HGHfnUcR9FPDibLs4oU", True)) # Google Maps, with detailed datetimes
+    unittest.main()

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,0 +1,14 @@
+import populartimes
+from pprint import pprint
+import logging
+
+logging.getLogger().setLevel(logging.INFO)
+
+key = "" # Add your API key
+
+if __name__ == "__main__":
+    pprint(populartimes.get(key, ["bar"], (48.142199, 11.566126), (48.132986, 11.580047), radius=5000, n_threads=1))
+    # Popular times
+    from populartimes.populartimes import get_populartimes
+    pprint(get_populartimes("Hirschau Gyßlingstraße 15, 80805 München, Germany", None)) # Google search
+    pprint(get_populartimes(None, "ChIJw-H-HGHfnUcR9FPDibLs4oU", True)) # Google Maps, with detailed datetimes


### PR DESCRIPTION
- Fix various issues in get_circle_centers (infinite loop, wrong use of radius). Use geopy instead.
- Popular times: Moved to another file. Random user agent. Use requests instead of urllib.
- Popular times: Other method using Google Maps with the exact place ID. It should also be possible to easily retrieve the current popularity.
- Popular times: Add option to output popular times as datetime: popularity dictionary.
- Test script.
- Updated README
- TODO file